### PR TITLE
Update sort-class-members config

### DIFF
--- a/rules/sort-class-members.js
+++ b/rules/sort-class-members.js
@@ -4,7 +4,7 @@ module.exports = {
   'plugins': [ 'sort-class-members' ],
   'rules': {
     'sort-class-members/sort-class-members': [2, {
-      'groups': {
+      'groups': [{
         'constructor': {
           'kind': 'constructor',
           'name': 'constructor'
@@ -69,7 +69,7 @@ module.exports = {
           'type': 'property',
           'name': '/[^_].+/'
         }
-      },
+      }],
       'order': [
         '[public-properties]',
         '[constructor]',


### PR DESCRIPTION
### Description 
Update sort-class-members config

`eslint-plugin-sort-class-members@v1.2.0` includes a [fix](https://github.com/bryanrsmith/eslint-plugin-sort-class-members/pull/41) for the warning `can't resolve reference #/definitions/order from id #` when running `^eslint@4.x`. 

When `eslint-plugin-sort-class-members@v1.2.0` is used with `zendeskgarden/eslint-config`, the following error shows up when running `eslint`:
```
Configuration for rule "sort-class-members/sort-class-members" is invalid:
    Value "[object Object]" should be array.
```
This pull request updates the `sort-class-members` rule to address the error. This fix is compatible for projects using the `eslint-plugin-sort-class-members@^v1.x.x` package.