### PR TITLE
fix: use default CircleCI node_modules cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       - checkout
       - node/with-cache:
           cache-key: yarn.lock
-          dir: ~/.cache/yarn
           steps:
             - run: yarn --frozen-lockfile
       - persist_to_workspace:


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Follow-on from zendeskgarden/react-components#683