### PR TITLE
fix: `space-before-function-paren` handling for async functions

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -219,7 +219,11 @@ module.exports = {
     // require or disallow space before blocks
     'space-before-blocks': 2,
     // require or disallow space before function opening parenthesis
-    'space-before-function-paren': [2, 'never'],
+    'space-before-function-paren': [2, {
+      anonymous: 'never',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
     // require or disallow spaces inside parentheses
     'space-in-parens': 2,
     // require spaces around operators


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Current `never` setting doesn't allow the following IIFE format to be properly linted:

```
(async () => {
  const x = await foo();

  return x;
})();
```
