### PR TITLE
fix: prevent husky from running on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "scripts": {
     "format": "prettier-package-json --write",
-    "postinstall": "husky install",
     "lint": "eslint index.js plugins/*.js rules/*.js",
+    "prepare": "husky install",
     "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'main' ] && standard-version --no-verify",
     "test": "yarn lint && yarn format && git diff --quiet"
   },


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Prevent script error when `@zendeskgarden/eslint-config` is installed as a dependency. Switch to `prepare` which is not run during package install.