### PR TITLE
feat!: add @typescript-eslint/no-unsafe-argument rule

### DIFF
--- a/plugins/typescript-semantics.js
+++ b/plugins/typescript-semantics.js
@@ -48,6 +48,8 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-type-arguments': 2,
     // warns if a type assertion does not change the type of an expression
     '@typescript-eslint/no-unnecessary-type-assertion': 2,
+    // disallows calling an function with an any type value
+    '@typescript-eslint/no-unsafe-argument': 2,
     // disallows assigning any to variables and properties
     '@typescript-eslint/no-unsafe-assignment': 2,
     // disallows calling an any type value


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds the `@typescript-eslint/no-unsafe-argument` rule with error status under the semantic type-checking typescript plugin. This is a breaking change, as any codebase that depends on this rule will need to have a dependency of `@typescript-eslint/eslint-plugin: 4.22.0` or higher.

Plugin dependency versions:
- `@typescript-eslint/eslint-plugin` ^4.22.0
- `eslint-plugin-jsx-a11y` ^6.4.0
- `eslint-plugin-react` ^7.22.0
- `eslint-plugin-react-hooks` ^4.2.0

## Detail

The addition of this rule was missed in #146. @hzhu I went ahead with this PR, as we expect this to get in for the remaining renovates in this cycle to pick it up.
