### PR TITLE
feat!: add react/prefer-exact-props rule

### DIFF
--- a/plugins/react.js
+++ b/plugins/react.js
@@ -177,6 +177,8 @@ module.exports = {
     'react/no-will-update-set-state': 2,
     // enforce ES5 or ES6 class for React Components
     'react/prefer-es6-class': 2,
+    // ensure only exact prop definitions are used
+    'react/prefer-exact-props': 0,
     // require read-only props
     'react/prefer-read-only-props': 0,
     // enforce stateless components to be written as a pure function


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR adds a corresponding Garden rule to maintain parity with `eslint-plugin-react` rules. This was ideally supposed to be part of [this Renovate PR](https://github.com/zendeskgarden/eslint-config/pull/164), but I missed it there.

This should be published as a breaking change.
