### PR TITLE
feat!: add new rules for jest, react, and typescript

### DIFF
--- a/plugins/jest.js
+++ b/plugins/jest.js
@@ -61,16 +61,16 @@ module.exports = {
     'jest/prefer-called-with': 0,
     // suggest using `expect.assertions()` OR `expect.hasAssertions()`
     'jest/prefer-expect-assertions': 0,
+    // suggest `await expect(...).resolves` over `expect(await ...)` syntax
+    'jest/prefer-expect-resolves': 2,
     // suggest having hooks before any test cases
     'jest/prefer-hooks-on-top': 0,
     // suggest using `jest.spyOn()`
     'jest/prefer-spy-on': 0,
     // suggest using `toStrictEqual()`
     'jest/prefer-strict-equal': 1,
-    // Deprecated: suggest using `toBeNull()`
-    'jest/prefer-to-be-null': 2,
-    // Deprecated: suggest using `toBeUndefined()`
-    'jest/prefer-to-be-undefined': 2,
+    // suggest using `toBe()` for primitive literals
+    'jest/prefer-to-be': 2,
     // suggest using `toContain()`
     'jest/prefer-to-contain': 2,
     // suggest using `toHaveLength()`
@@ -88,10 +88,6 @@ module.exports = {
     // enforce having return statement when testing with promises
     'jest/valid-expect-in-promise': 2,
     // enforce valid titles
-    'jest/valid-title': 2,
-    // suggest `await expect(...).resolves` over `expect(await ...)` syntax
-    'jest/prefer-expect-resolves': 2,
-    // suggest using `toBe()` for primitive literals
-    'jest/prefer-to-be': 2
+    'jest/valid-title': 2
   }
 };

--- a/plugins/jest.js
+++ b/plugins/jest.js
@@ -67,9 +67,9 @@ module.exports = {
     'jest/prefer-spy-on': 0,
     // suggest using `toStrictEqual()`
     'jest/prefer-strict-equal': 1,
-    // suggest using `toBeNull()`
+    // Deprecated: suggest using `toBeNull()`
     'jest/prefer-to-be-null': 2,
-    // suggest using `toBeUndefined()`
+    // Deprecated: suggest using `toBeUndefined()`
     'jest/prefer-to-be-undefined': 2,
     // suggest using `toContain()`
     'jest/prefer-to-contain': 2,
@@ -88,6 +88,10 @@ module.exports = {
     // enforce having return statement when testing with promises
     'jest/valid-expect-in-promise': 2,
     // enforce valid titles
-    'jest/valid-title': 2
+    'jest/valid-title': 2,
+    // suggest `await expect(...).resolves` over `expect(await ...)` syntax
+    'jest/prefer-expect-resolves': 2,
+    // suggest using `toBe()` for primitive literals
+    'jest/prefer-to-be': 2
   }
 };

--- a/plugins/react.js
+++ b/plugins/react.js
@@ -151,6 +151,8 @@ module.exports = {
     'react/no-is-mounted': 2,
     // prevent multiple component definition per file
     'react/no-multi-comp': 0,
+    // enforces the absence of a namespace in React elements (e.g. `<svg:circle />`)
+    'react/no-namespace': 2,
     // flag shouldComponentUpdate when extending PureComponent
     'react/no-redundant-should-component-update': 2,
     // prevent usage of the return value of React.render
@@ -207,8 +209,6 @@ module.exports = {
     'react/style-prop-object': 2,
     // prevent passing of children to void DOM elements (e.g. `<br />`)
     'react/void-dom-elements-no-children': 2,
-    // enforces the absence of a namespace in React elements (e.g. `<svg:circle />`)
-    'react/no-namespace': 2,
 
     // checks rules of hooks
     'react-hooks/rules-of-hooks': 2,

--- a/plugins/react.js
+++ b/plugins/react.js
@@ -207,6 +207,8 @@ module.exports = {
     'react/style-prop-object': 2,
     // prevent passing of children to void DOM elements (e.g. `<br />`)
     'react/void-dom-elements-no-children': 2,
+    // enforces the absence of a namespace in React elements (e.g. `<svg:circle />`)
+    'react/no-namespace': 2,
 
     // checks rules of hooks
     'react-hooks/rules-of-hooks': 2,

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -182,10 +182,10 @@ module.exports = {
     '@typescript-eslint/no-namespace': 2,
     // disallows using a non-null assertion after an optional chain expression
     '@typescript-eslint/no-non-null-asserted-optional-chain': 2,
-    // disallows non-null assertions using the `!` postfix operator
-    '@typescript-eslint/no-non-null-assertion': 0,
     // disallows using the non-null assertion on the left operand of the nullish coalescing operator
     '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2,
+    // disallows non-null assertions using the `!` postfix operator
+    '@typescript-eslint/no-non-null-assertion': 0,
     // disallow the use of parameter properties in class constructors
     '@typescript-eslint/no-parameter-properties': 1,
     // disallow variable redeclaration

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -190,6 +190,8 @@ module.exports = {
     '@typescript-eslint/no-redeclare': bestPractices['no-redeclare'],
     // disallows invocation of `require()`
     '@typescript-eslint/no-require-imports': 2,
+    // allows to specify new option `allowTypeImport` for path or pattern
+    '@typescript-eslint/no-restricted-imports': 0,
     // disallow variable declarations from shadowing variables declared in the outer scope
     '@typescript-eslint/no-shadow': variables['no-shadow'],
     // disallow aliasing `this`
@@ -249,11 +251,6 @@ module.exports = {
     // warns for any two overloads that could be unified into one by using a union or an optional/rest parameter
     '@typescript-eslint/unified-signatures': 2,
     // disallows using the non-null assertion on the left operand of the nullish coalescing operator
-    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2,
-    // allows to specify new option `allowTypeImport` for path or pattern
-    '@typescript-eslint/no-restricted-imports': [2, {
-      paths: [],
-      patterns: []
-    }]
+    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2
   }
 };

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -45,6 +45,7 @@ module.exports = {
     'no-new-symbol': 0,
     'no-obj-calls': 0,
     'no-redeclare': 0,
+    'no-restricted-imports': 0,
     'no-shadow': 0,
     'no-setter-return': 0,
     'no-this-before-super': 0,

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -247,6 +247,13 @@ module.exports = {
     // requires type annotations to exist
     '@typescript-eslint/typedef': 2,
     // warns for any two overloads that could be unified into one by using a union or an optional/rest parameter
-    '@typescript-eslint/unified-signatures': 2
+    '@typescript-eslint/unified-signatures': 2,
+    // disallows using the non-null assertion on the left operand of the nullish coalescing operator
+    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2,
+    // allows to specify new option `allowTypeImport` for path or pattern
+    '@typescript-eslint/no-restricted-imports': [2, {
+      paths: [],
+      patterns: []
+    }]
   }
 };

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -184,6 +184,8 @@ module.exports = {
     '@typescript-eslint/no-non-null-asserted-optional-chain': 2,
     // disallows non-null assertions using the `!` postfix operator
     '@typescript-eslint/no-non-null-assertion': 0,
+    // disallows using the non-null assertion on the left operand of the nullish coalescing operator
+    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2,
     // disallow the use of parameter properties in class constructors
     '@typescript-eslint/no-parameter-properties': 1,
     // disallow variable redeclaration
@@ -249,8 +251,6 @@ module.exports = {
     // requires type annotations to exist
     '@typescript-eslint/typedef': 2,
     // warns for any two overloads that could be unified into one by using a union or an optional/rest parameter
-    '@typescript-eslint/unified-signatures': 2,
-    // disallows using the non-null assertion on the left operand of the nullish coalescing operator
-    '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 2
+    '@typescript-eslint/unified-signatures': 2
   }
 };

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -192,8 +192,8 @@ module.exports = {
     '@typescript-eslint/no-redeclare': bestPractices['no-redeclare'],
     // disallows invocation of `require()`
     '@typescript-eslint/no-require-imports': 2,
-    // allows to specify new option `allowTypeImport` for path or pattern
-    '@typescript-eslint/no-restricted-imports': 0,
+    // restrict usage of specified node imports
+    '@typescript-eslint/no-restricted-imports': es6['no-restricted-imports'],
     // disallow variable declarations from shadowing variables declared in the outer scope
     '@typescript-eslint/no-shadow': variables['no-shadow'],
     // disallow aliasing `this`


### PR DESCRIPTION
BREAKING CHANGE added
- @typescript-eslint/no-non-null-asserted-nullish-coalescing
- @typescript-eslint/no-restricted-imports
- jest/prefer-expect-resolves
- jest/prefer-to-be
- react/no-namespace

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

Adding the new rules introduced by the updates to the `jest`, `react` and `typescript-eslint` plugins.

## Detail

There were three plugins that were updated that introduced new rules:

`@typescript-eslint/eslint-plugin` version `4.32.0` [CHANGELOG](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md#4320-2021-09-27)
- @typescript-eslint/no-non-null-asserted-nullish-coalescing
- @typescript-eslint/no-restricted-imports

`eslint-plugin-jest` version `24.5.0` [CHANGELOG](https://github.com/jest-community/eslint-plugin-jest/blob/main/CHANGELOG.md#2450-2021-09-29)
- jest/prefer-expect-resolves
- jest/prefer-to-be

** There were deprecations made to the rule `jest/prefer-to-be-null` and `jest/prefer-to-be-undefined` in favor of `jest/prefer-to-be` - [more detail can be found in this PR](https://github.com/jest-community/eslint-plugin-jest/pull/864)

`eslint-plugin-react` version `7.26.0` [CHANGELOG](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#7260---20210920)
- react/no-namespace