### PR TITLE
docs: update babel-eslint to @babel/eslint-parser in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ selection of associated [plugins](#plugins).
 ## Installation
 
 ```sh
-npm install eslint babel-eslint eslint-plugin-node @zendeskgarden/eslint-config
+npm install eslint @babel/eslint-parser eslint-plugin-node @zendeskgarden/eslint-config
 ```
 
 ## Usage


### PR DESCRIPTION
## Description

Updating install command to replace `babel-eslint` with `@babel/eslint-parser` that we currently support.
