### PR TITLE
chore(rules)!: adds new rules missed in v31

### DIFF
--- a/plugins/react.js
+++ b/plugins/react.js
@@ -19,6 +19,13 @@ module.exports = {
     }
   },
   rules: {
+    // enforces using semantic DOM elements over the ARIA role property.
+    'jsx-a11y/prefer-tag-over-role': 0,
+    // enforce that aria-hidden="true" is not set on focusable elements.
+    'jsx-a11y/no-aria-hidden-on-focusable': 2,
+    // enforces descriptive text for anchor tags.
+    'jsx-a11y/anchor-ambiguous-text': 1,
+
     // enforces consistent naming for boolean props
     'react/boolean-prop-naming': 1,
     // forbid "button" element without an explicit "type" attribute
@@ -118,7 +125,7 @@ module.exports = {
     // prevent JSX prop spreading
     'react/jsx-props-no-spreading': 0,
     // enforce default props alphabetical sorting
-    'react/jsx-sort-default-props': 0,
+    'react/sort-default-props': 0,
     // enforce props alphabetical sorting
     'react/jsx-sort-props': 0,
     // validate whitespace in and around the JSX opening and closing brackets
@@ -161,6 +168,8 @@ module.exports = {
     'react/no-multi-comp': 0,
     // enforces the absence of a namespace in React elements (e.g. `<svg:circle />`)
     'react/no-namespace': 2,
+    // disallow usage of referential-type variables as default param in functional components
+    'react/no-object-type-as-default-prop': 0,
     // flag shouldComponentUpdate when extending PureComponent
     'react/no-redundant-should-component-update': 2,
     // prevent usage of the return value of React.render

--- a/plugins/react.js
+++ b/plugins/react.js
@@ -20,11 +20,7 @@ module.exports = {
   },
   rules: {
     // enforces using semantic DOM elements over the ARIA role property.
-    'jsx-a11y/prefer-tag-over-role': 0,
-    // enforce that aria-hidden="true" is not set on focusable elements.
-    'jsx-a11y/no-aria-hidden-on-focusable': 2,
-    // enforces descriptive text for anchor tags.
-    'jsx-a11y/anchor-ambiguous-text': 1,
+    'jsx-a11y/prefer-tag-over-role': 2,
 
     // enforces consistent naming for boolean props
     'react/boolean-prop-naming': 1,
@@ -124,8 +120,6 @@ module.exports = {
     'react/jsx-props-no-multi-spaces': 2,
     // prevent JSX prop spreading
     'react/jsx-props-no-spreading': 0,
-    // enforce default props alphabetical sorting
-    'react/sort-default-props': 0,
     // enforce props alphabetical sorting
     'react/jsx-sort-props': 0,
     // validate whitespace in and around the JSX opening and closing brackets
@@ -218,6 +212,8 @@ module.exports = {
     'react/self-closing-comp': 2,
     // enforce component methods order
     'react/sort-comp': 0,
+    // enforce default props alphabetical sorting
+    'react/sort-default-props': 0,
     // enforce propTypes declarations alphabetical sorting
     'react/sort-prop-types': 0,
     // state initialization in an ES6 class component should be in a constructor

--- a/plugins/typescript-semantics.js
+++ b/plugins/typescript-semantics.js
@@ -7,6 +7,7 @@
 
 const bestPractices = require('../rules/best-practices').rules;
 const possibleErrors = require('../rules/possible-errors').rules;
+const stylisticIssues = require('../rules/stylistic-issues').rules;
 
 module.exports = {
   plugins: ['@typescript-eslint'],
@@ -14,21 +15,18 @@ module.exports = {
   rules: {
     // Disable ESLint rules that are handled by TypeScript
     'dot-notation': 0,
+    'key-spacing': 0,
     'no-implied-eval': 0,
     'no-return-await': 0,
     'no-throw-literal': 0,
     'require-await': 0,
-    'key-spacing': 0,
 
     // disallows awaiting a value that is not a `Thenable`
     '@typescript-eslint/await-thenable': 2,
     // enforce dot notation whenever possible
     '@typescript-eslint/dot-notation': bestPractices['dot-notation'],
     // enforce consistent spacing between keys and values in object literal properties
-    '@typescript-eslint/key-spacing': [2, {
-      beforeColon: false,
-      afterColon: true
-    }],
+    '@typescript-eslint/key-spacing': stylisticIssues['key-spacing'],
     // requires that `.toString()` is only called on objects which provide useful information when stringified
     '@typescript-eslint/no-base-to-string': 2,
     // requires expressions of type void to appear in statement position

--- a/plugins/typescript-semantics.js
+++ b/plugins/typescript-semantics.js
@@ -18,11 +18,17 @@ module.exports = {
     'no-return-await': 0,
     'no-throw-literal': 0,
     'require-await': 0,
+    'key-spacing': 0,
 
     // disallows awaiting a value that is not a `Thenable`
     '@typescript-eslint/await-thenable': 2,
     // enforce dot notation whenever possible
     '@typescript-eslint/dot-notation': bestPractices['dot-notation'],
+    // enforce consistent spacing between keys and values in object literal properties
+    '@typescript-eslint/key-spacing': [2, {
+      beforeColon: false,
+      afterColon: true
+    }],
     // requires that `.toString()` is only called on objects which provide useful information when stringified
     '@typescript-eslint/no-base-to-string': 2,
     // requires expressions of type void to appear in statement position


### PR DESCRIPTION

- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Forgot a handful of rules from the last renovate update.

## Detail

- @typescript-eslint/key-spacing
- react/no-object-type-as-default-prop
- react/sort-default-props
- jsx-a11y/prefer-tag-over-role
- jsx-a11y/no-aria-hidden-on-focusable
- jsx-a11y/anchor-ambiguous-text