### PR TITLE
fix: moves use-unknown-in-catch-callback-variable to semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "peerDependencies": {
         "@babel/eslint-parser": "^7.15.0",
         "eslint": "^8.56.0",
-        "eslint-plugin-n": "^11.1.0 || ^14.0.0"
+        "eslint-plugin-n": "^14.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/plugins/typescript-semantics.js
+++ b/plugins/typescript-semantics.js
@@ -110,6 +110,8 @@ module.exports = {
     // exhaustiveness checking in switch with union type
     '@typescript-eslint/switch-exhaustiveness-check': 2,
     // enforces unbound methods are called with their expected scope
-    '@typescript-eslint/unbound-method': 2
+    '@typescript-eslint/unbound-method': 2,
+    // requires type annotation of catch() parameter remain unknown
+    '@typescript-eslint/use-unknown-in-catch-callback-variable': 2
   }
 };

--- a/plugins/typescript.js
+++ b/plugins/typescript.js
@@ -208,8 +208,6 @@ module.exports = {
     // requires type annotations to exist
     '@typescript-eslint/typedef': 2,
     // warns for any two overloads that could be unified into one by using a union or an optional/rest parameter
-    '@typescript-eslint/unified-signatures': 2,
-    // requires type annotation of catch() parameter remain unknown
-    '@typescript-eslint/use-unknown-in-catch-callback-variable': 2
+    '@typescript-eslint/unified-signatures': 2
   }
 };


### PR DESCRIPTION
## Description

Moves `use-unknown-in-catch-callback-variable` to `typescript-semantics ` for correct grouping. Fixes an error from v39 where the rule didn't have the correct parser option.

## Detail

Tested by linking this branch to `react-components` (with some dependency updates needed for v39) and running `npm run lint:js`. No errors/warnings.

Error in question:

<img width="833" alt="Screenshot 2024-04-01 at 11 10 45 AM" src="https://github.com/zendeskgarden/eslint-config/assets/3946669/d22e9cb8-0b98-4ec6-8136-373bb63d8b3b">