### PR TITLE
fix(react): plugin rules eslint v9 compatibility for `react-hooks`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/eslint-parser": "7.25.1",
+        "@eslint/compat": "1.1.1",
         "eslint-plugin-jest": "28.8.3",
         "eslint-plugin-jsx-a11y": "6.10.0",
         "eslint-plugin-n": "17.10.2",
@@ -1007,6 +1008,14 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.1.1.tgz",
+      "integrity": "sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-array": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "7.25.1",
+    "@eslint/compat": "1.1.1",
     "eslint-plugin-jest": "28.8.3",
     "eslint-plugin-jsx-a11y": "6.10.0",
     "eslint-plugin-n": "17.10.2",

--- a/plugins/react.js
+++ b/plugins/react.js
@@ -5,6 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import { fixupPluginRules } from '@eslint/compat';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactPlugin from 'eslint-plugin-react';
@@ -12,7 +13,8 @@ import reactPlugin from 'eslint-plugin-react';
 export default {
   plugins: {
     react: reactPlugin,
-    'react-hooks': reactHooksPlugin,
+    // TODO remove fixup when eslint-plugin-react-hooks 5.x is released
+    'react-hooks': fixupPluginRules(reactHooksPlugin),
     'jsx-a11y': jsxA11yPlugin
   },
   languageOptions: {


### PR DESCRIPTION
## Description

Undoes the premature compatiblity removal from #237. Need to wait for `react-hooks` v5 to remove.
